### PR TITLE
Adding sitegr1 function used in ADSL

### DIFF
--- a/code/utils/format_sitegr1.r
+++ b/code/utils/format_sitegr1.r
@@ -1,0 +1,17 @@
+# Load required packages
+library(dplyr)        # Data manipulation
+
+#' Derive pooled site group
+#'
+#' `format_sitegr1` derives the `SITEGR1` variable, which pools sites with fewer than 3 subjects in any one treatment
+#' group.
+#'
+#' @param x The input vector of values to format
+#'
+#' @export
+format_sitegr1 <- function(x) {
+  case_when(
+    x %in% c("702", "706", "707", "711", "714", "715", "717") ~ "900",
+    TRUE ~ x
+  )
+}


### PR DESCRIPTION
Addresses #60 

@bms63 Ben, while working on it, locally I saw that you have created 60-utils branch, but I cannot find it in the repo. Did you remove it?

There is only one function from the pilot5-helper-fcns.r file used in datasets. 

1) I'm not sure we actually want to have this file, because I don't see where it could be used outside of ADSL, so it is logical just to have this function inside the adsl.r program.
2) Previous combined utils file did not import any packages, but I'm getting an error from lintr, so I have specified the required packages at the beginning. Is it fine? 